### PR TITLE
Fix: Keyboard overlaps input fields on Add/Edit Password screens

### DIFF
--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,7 +83,9 @@ fun AddPasswordScreen(
     val isAdded by addEditViewModel.isAdded.observeAsState(false)
 
     Scaffold(
-        modifier.fillMaxSize(),
+        modifier
+            .fillMaxSize()
+            .imePadding(),
         topBar = {
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
@@ -94,7 +99,8 @@ fun AddPasswordScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(16.dp),
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -256,7 +262,7 @@ fun AddPasswordScreen(
             )
 
             Spacer(modifier = Modifier.weight(1f))
-
+            Spacer(modifier = Modifier.height(20.dp))
             UCButton(
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -78,7 +81,7 @@ fun EditPasswordScreen(
     }
 
     Scaffold(
-        modifier.fillMaxSize(),
+        modifier.fillMaxSize().imePadding(),
         topBar = {
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
@@ -94,7 +97,8 @@ fun EditPasswordScreen(
                 .fillMaxSize()
                 .background(SurfaceVariantLight)
                 .padding(paddingValues)
-                .padding(16.dp),
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
@@ -201,7 +205,7 @@ fun EditPasswordScreen(
 
 
             Spacer(modifier = Modifier.weight(1f))
-
+            Spacer(modifier = Modifier.height(20.dp))
             UCButton(
                 modifier = Modifier
                     .fillMaxWidth(),


### PR DESCRIPTION
### Fixes #252

Now, when the keyboard appears, the view scrolls automatically to keep the focused text field visible.

✅ I’ve applied this fix to both:
- Add Password screen
- Edit Password screen

https://github.com/user-attachments/assets/9eeba011-b4b7-47e8-987d-f94e444f5507

